### PR TITLE
Pedidos en el panel de administradores

### DIFF
--- a/api/src/controllers/requests/index.js
+++ b/api/src/controllers/requests/index.js
@@ -4,8 +4,38 @@ const nodemailer = require('nodemailer')
 const hbs = require('nodemailer-handlebars');
 const path = require('path')
 
+function checkFields(fields) {
+    for (const field in fields) {
+        const value = fields[field]
+        switch (field) {
+            case 'rol':
+                if(!value) return;
+                const roles = ['Administrador', 'Estudiante', 'Graduado', 'TA', 'Henry Hero']
+                if(!roles.includes(value)) return 'Rol invalido'
+                break;
+            case 'approve':
+                if(!value) return 'Debe especificar el tipo de aprobado'
+                if(value !== true && value !== false) return 'approve debe ser true o false'
+                break;
+            case 'type':
+                if(value && value !== 'Rol' && value !== 'Registro') return 'Tipo de pedido invalido.'
+            case 'page':
+                if(!value) return 'Numero de pagina requerido'
+                if (value <= 0) return 'Pagina no puede ser menor o igual a 0'
+                break;
+            case 'rid':
+                if(!value) return 'Id de request requerido'
+            default:
+                break;
+        }
+    }
+    return ''
+}
+
 const createRegisterRequest = async (req, res) => {
     const { rol } = req.body
+    const message = checkFields({ rol })
+    if (message) return res.status(400).json({ message })
     try {
         const duplicated = await Request.findOne({ user: req.id })
         if (duplicated) return res.status(409).json({ message: `Usuario ${req.id} ya tiene un pedido pendiente!` })
@@ -19,6 +49,8 @@ const createRegisterRequest = async (req, res) => {
 
 const createRolRequest = async (req, res) => {
     const { rol } = req.body
+    const message = checkFields({ rol })
+    if (message) return res.status(400).json({ message })
     try {
         const duplicated = await Request.findOne({ user: req.id })
         if (duplicated) return res.status(409).json({ message: `Usuario ${req.id} ya tiene un pedido pendiente!` })
@@ -32,6 +64,8 @@ const createRolRequest = async (req, res) => {
 
 const completeRegisterRequest = async (req, res) => {
     const { rid, approve, reason } = req.body
+    const message = checkFields({ rid, approve })
+    if (message) return res.status(400).json({ message })
     try {
         const request = await Request.findById(rid)
         if (!request) return res.status(404).json({ message: 'Pedido no existe o ya fue completado' })
@@ -67,6 +101,7 @@ const completeRegisterRequest = async (req, res) => {
         };
 
         if (!approve) {
+            if(!reason) return res.status(400).json({message: 'Debe incluir una razon'})
             mailOptions.template = 'registerR'
             mailOptions.context = { reason }
             response = { message: 'Peticion rechazada!' }
@@ -94,6 +129,8 @@ const completeRegisterRequest = async (req, res) => {
 
 const completeRolRequest = async (req, res) => {
     const { rid, approve, reason } = req.body
+    const message = checkFields({ rid, approve })
+    if (message) return res.status(400).json({ message })
     try {
         const request = await Request.findById(rid)
         if (!request) return res.status(404).json({ message: 'Pedido no existe o ya fue completado' })
@@ -129,6 +166,7 @@ const completeRolRequest = async (req, res) => {
         };
 
         if (!approve) {
+            if(!reason) return res.status(400).json({message: 'Debe incluir una razon'})
             mailOptions.template = 'rolR'
             mailOptions.context = { reason }
             response = { message: 'Peticion rechazada!' }
@@ -155,22 +193,42 @@ const completeRolRequest = async (req, res) => {
 }
 
 const getRequests = async (req, res) => {
-    const { page } = req.query
-    if (!page) return res.status(400).json({ message: 'Numero de pagina requerido.' })
+    const { page, type} = req.query
+    const message = checkFields({ page })
+    if (message) return res.status(400).json({ message })
 
-    try {
-        const numberOfDocs = await Request.countDocuments()
-        const maxPages = Math.ceil(numberOfDocs / 10)
-        const requests = await Request.find()
-            .sort({ createdAt: 1 })
-            .skip(page * 10 - 10)
-            .limit(10)
-            .populate('user', { mail: 1, userSlack: 1, rol: 1 })
-        //te devuelve las requests ordenadas de mas viejas a mas nuevas
-        res.json({ message: 'Pedidos encontrados!', requests, maxPages })
-    } catch (error) {
-        res.json({ message: error.message })
+    function buildQuery() {
+        let query = ''
+
+        if (type) {
+            query = query
+                ? query.find({ type })
+                : Request.find({ type })
+        }
+
+        if(!query) query = Request.find()
+        return query
     }
+    //busqueda para obtener usuarios paginados
+    const searchPaginatedRequests = buildQuery()
+        .skip(page * 10 - 10)
+        .limit(10)
+        .sort({ createdAt: 1 })
+        .populate('user', { mail: 1, userSlack: 1, rol: 1 })
+
+    //busqueda para obtener numero maximo de pagina
+    const searchAllRequests = buildQuery().select({ _id: 1 })
+
+    //Ejecuto dos busquedas al mismo tiempo
+    Promise.all([
+        searchPaginatedRequests,
+        searchAllRequests
+    ]).then(([paginatedDocs, allDocs]) => {
+        const maxPages = Math.ceil(allDocs.length / 10)
+        res.json({ message: 'Pedidos encontrados!', requests: paginatedDocs, maxPages })
+    }).catch(error => {
+        res.json({ message: error.message })
+    })
 }
 
 module.exports = {

--- a/api/src/routes/request.js
+++ b/api/src/routes/request.js
@@ -2,8 +2,8 @@ const router = require('express').Router();
 const { checkAdmin } = require('../controllers/middlewares/index')
 const { createRegisterRequest, createRolRequest, completeRegisterRequest, completeRolRequest, getRequests } = require('../controllers/requests')
 
-router.post('/register', createRegisterRequest)
-router.put('/register', checkAdmin, completeRegisterRequest)
+router.post('/registro', createRegisterRequest)
+router.put('/registro', checkAdmin, completeRegisterRequest)
 router.post('/rol', createRolRequest)
 router.put('/rol', checkAdmin, completeRolRequest)
 router.get('/', checkAdmin, getRequests)

--- a/client/src/Components/Admin/Accounts.jsx
+++ b/client/src/Components/Admin/Accounts.jsx
@@ -15,7 +15,7 @@ import { useSelector, useDispatch } from "react-redux";
 import SearchbarAdmin from "./SearchbarAdmin";
 import { useAuth } from "../AuthComponents/AuthContext";
 import PaginatedAdmin from "./PaginatedAdmin";
-import { getUsers } from "../../slices/userSlice";
+import { getUsers, setPage } from "../../slices/userSlice";
 
 const Accounts = () => {
   const { user } = useAuth();
@@ -28,9 +28,13 @@ const Accounts = () => {
   const maxPag = useSelector((state) => state.user.usersMaxPages);
 
   useEffect(() => {
-    dispatch(getUsers({ token, page: accounts.page }));
-  }, [dispatch, accounts.page]);
+    dispatch(setPage(1))
+  }, [])
 
+  useEffect(() => {
+      dispatch(getUsers({ token, page: accounts.page }));
+  }, [dispatch, accounts.page]);
+  
   return (
     <Flex>
       <Sidebar />

--- a/client/src/Components/Admin/ReqAdmin.jsx
+++ b/client/src/Components/Admin/ReqAdmin.jsx
@@ -2,7 +2,6 @@ import {
   Table,
   Thead,
   Tbody,
-  Tfoot,
   Tr,
   Th,
   Td,
@@ -10,35 +9,79 @@ import {
   Flex,
   Button,
   Text,
+  useToast,
+  Textarea,
+  Modal,
+  ModalContent,
+  ModalOverlay,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  useDisclosure,
+  Divider,
 } from "@chakra-ui/react";
 import React, { useEffect, useState } from "react";
+import { SearchIcon } from "@chakra-ui/icons";
 import { useDispatch, useSelector } from "react-redux";
 import { useAuth } from "../AuthComponents/AuthContext";
-import SearchbarAdmin from "./SearchbarAdmin";
+import SearchbarReq from "./SearchbarReq";
 import Sidebar from "./Sidebar";
 import axios from "axios";
-import { getRequest } from "../../slices/userSlice";
+import { getRequest, setPage } from "../../slices/userSlice";
 import PaginatedAdmin from "./PaginatedAdmin";
+import API_URL from "../../config/environment";
 
 const ReqAdmin = () => {
-  const dispatch = useDispatch();
+  const { isOpen, onOpen, onClose } = useDisclosure()
 
+  const dispatch = useDispatch();
   const { user } = useAuth();
   let token = user.accessToken;
+  const toast = useToast()
+
+  const [type, setType] = useState('')
+
+  const [reason, setReason] = useState('')
 
   const page = useSelector((state) => state.user.page);
   const req = useSelector((state) => state.user.requests);
   const maxPag = useSelector((state) => state.user.reqMaxPages);
 
   useEffect(() => {
-    dispatch(getRequest({ token, page }));
-  }, [dispatch, page]);
+    dispatch(setPage(1))
+    dispatch(getRequest({ token, page: 1, type}));
+  }, []);
+
+  const complete = async (request, approve) => {
+    try {
+      await axios.put(`${API_URL}/request/${request.type.toLowerCase()}`, { rid:request._id, approve, reason}, {headers: {
+        Authorization: `Bearer ${token}`
+      }})
+      toast({
+        description: "Pedido completado!",
+        duration: 2000,
+        position: "bottom-left",
+        status: "success",
+        isClosable: true
+      })
+      dispatch(getRequest({token, page, type}))
+    } catch (error) {
+      if(error.response.status === 498) return toast({
+        description: "Ocurrio un error inesperado",
+        duration: 2000,
+        position: "bottom-left",
+        status: "error",
+        isClosable: true
+      })
+    }
+  }
 
   return (
     <Flex>
       <Sidebar />
       <div style={{ margin: "20px auto" }}>
-        <SearchbarAdmin name="Petición" op1="Registro" op2="Cambio de rol" />
+        <SearchbarReq setType={setType}/>
         <Text
           mb="20px"
           align="center"
@@ -72,10 +115,49 @@ const ReqAdmin = () => {
                       <Td textAlign="center"> {req.rol} </Td>
                       <Td textAlign="center">Registro</Td>
                       <Td>
-                        <Button mr="3px" colorScheme="green">
+                        <Button mr="3px" colorScheme="green" onClick={() => complete(req, true)}>
                           Aceptar
                         </Button>
-                        <Button colorScheme="red">Denegar</Button>
+                        <Button colorScheme="red" onClick={onOpen}>Denegar</Button>
+                        <Modal
+                        isOpen={isOpen}
+                        onClose={() => {
+                          setReason('')
+                          onClose()
+                        }}
+                    >
+                        <ModalOverlay display={'flex'} alignItems='center'>
+                            <ModalContent
+                                margin={'8px'}
+                                width='95%'
+                                alignSelf={'center'}
+                                >
+                                <ModalHeader>Razon de rechazo</ModalHeader>
+                                <ModalCloseButton />
+                                <Divider backgroundColor={'#FFFF01'} h='3px' />
+                                <ModalBody pb={6}>
+                                        <Textarea
+                                            placeholder='Razon...'
+                                            onChange={(e) => setReason(e.target.value)}
+                                            value={reason}
+                                        />
+                                </ModalBody>
+
+                                <ModalFooter>
+                                    <Button onClick={() => {
+                                      complete(req, false)
+                                      onClose()
+                                    }}backgroundColor={'black'} color='#E4E400' mr={3} _hover={{ backgroundColor: '#E4E400', color: 'black' }}>
+                                        Denegar
+                                    </Button>
+                                    <Button onClick={() => {
+                                      setReason('')
+                                      onClose()
+                                    }} _hover={{ background: "tomato" }}>Cancelar</Button>
+                                </ModalFooter>
+                            </ModalContent>
+                        </ModalOverlay>
+                    </Modal>
                       </Td>
                     </Tr>
                   ))}

--- a/client/src/Components/Admin/SearchbarReq.jsx
+++ b/client/src/Components/Admin/SearchbarReq.jsx
@@ -1,0 +1,56 @@
+import { SearchIcon } from "@chakra-ui/icons";
+import {
+  Flex,
+  FormControl,
+  HStack,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Select,
+  Text,
+} from "@chakra-ui/react";
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { getRequest, setPage } from "../../slices/userSlice";
+import { useAuth } from "../AuthComponents/AuthContext";
+
+const SearchbarAdmin = ({setType}) => {
+  const dispatch = useDispatch();
+
+  const page = useSelector((state) => state.user.page);
+
+  const { user } = useAuth();
+  let token = user.accessToken;
+
+  const handleChangeType = (e) => {
+    e.preventDefault();
+    setType(e.target.value)
+    dispatch(setPage(1))
+    dispatch(getRequest({token, page, type: e.target.value}))
+  };
+
+  return (
+    <div>
+      <FormControl m="auto" fontSize=".9rem" mb="60px" w='100%'>
+        <HStack
+          align="center"
+          bg="#F2F2F2"
+          p="1% 2%"
+          spacing="3.5%"
+          borderRadius="1.5rem"
+          w='100%'
+        >
+            <Text w="4rem"> Pedidos:</Text>
+            <Select onChange={handleChangeType} borderRadius="10rem">
+                <option value=''>Todos</option>
+                <option value='Registro'> Registro </option>
+                <option value='Rol'> Rol </option>
+                
+            </Select>
+        </HStack>
+      </FormControl>
+    </div>
+  );
+};
+
+export default SearchbarAdmin;

--- a/client/src/Components/Admin/Sidebar.jsx
+++ b/client/src/Components/Admin/Sidebar.jsx
@@ -3,10 +3,12 @@ import React, { useState } from "react";
 import { FiBriefcase, FiHome, FiMenu, FiUser } from "react-icons/fi";
 import { Navigate, useNavigate } from "react-router-dom";
 import NavItem from "./NavItem";
+import { useSelector } from "react-redux";
 
 const Sidebar = () => {
   const [navSize, setNavSize] = useState("large");
   const navigate = useNavigate();
+  const userData = useSelector((state) => state.user.user);
 
   const handleMenuSize = () => {
     if (navSize === "small") {
@@ -67,7 +69,7 @@ const Sidebar = () => {
         display={navSize === "small" ? "none" : "flex"}
       >
         <Heading as="h3" size="sm">
-          Nombre del usuario
+          {userData?.userSlack}
         </Heading>
         <Text color="gray">Admin</Text>
       </Flex>

--- a/client/src/slices/userSlice.js
+++ b/client/src/slices/userSlice.js
@@ -12,6 +12,7 @@ const initialState = {
   reqMaxPages: 0,
   usersMaxPages: 0,
   maxPages: 0,
+  users: [],
 };
 
 export const getUsers = createAsyncThunk(
@@ -33,10 +34,10 @@ export const getUsers = createAsyncThunk(
 
 export const getRequest = createAsyncThunk(
   "get/request",
-  async ({ token, page }) => {
+  async ({ token, page, type }) => {
     try {
       const { data } = await axios.get(
-        `http://localhost:3001/request?page=${page}`,
+        `http://localhost:3001/request?page=${page}&type=${type}`,
         {
           headers: { Authorization: "Bearer " + token },
         }
@@ -131,11 +132,15 @@ export const userSlice = createSlice({
   },
 });
 
-export const { saveUser, saveQuestions, saveAnswers, nextPage, previousPage, setPage } =
-  userSlice.actions;
-
-export const { saveUser, saveQuestions, saveAnswers, nextPage, previousPage, setPage } =
-  userSlice.actions;
+export const {
+  saveUser,
+  saveQuestions,
+  nextPage,
+  previousPage,
+  setPage,
+  filterByRol,
+  saveAnswers,
+} = userSlice.actions;
 
 export default userSlice.reducer;
 


### PR DESCRIPTION
# Pedidos en el panel de administradores
## api 🗄️ 
### routes/request:
* cambie /register por /registro
### controllers/requests
* checkField: nueva funcion para verificar datos de entrada
* getRequests: agregue nuevo filtro type
## client 🧑‍🎨 
### Accounts
* cuando se renderiza, setea el numero de pagina en 1
### SideBar
* muestra el usuario de slack del usuario en sesion
### userSlice:
* getRequest: agregue filtro por tipo
* agregue estado users
### ReqAdmin:
* cuando se renderiza se setea el numero de pagina en 1
* agregue funcion para aprobar o denegar pedidos
* cambie SearchbarAdmin por searchBarReq
### SearchBarReq: 
* nuevo componente que permite filtrar pedidos por tipo de pedido
